### PR TITLE
:sparkles: Adds ChangeTracker extension methods for save-time modific…

### DIFF
--- a/src/Configuration.Persistence/ChangeTrackerExtensions.cs
+++ b/src/Configuration.Persistence/ChangeTrackerExtensions.cs
@@ -1,0 +1,77 @@
+namespace Kritikos.Configuration.Persistence
+{
+	using System;
+	using System.Collections.Generic;
+	using System.Linq;
+
+	using Kritikos.Configuration.Persistence.Abstractions;
+
+	using Microsoft.EntityFrameworkCore;
+	using Microsoft.EntityFrameworkCore.ChangeTracking;
+
+	public static class ChangeTrackerExtensions
+	{
+#pragma warning disable CS0419 // Ambiguous reference in cref attribute
+		/// <summary>
+		/// Configures preset actions that will be applied on all matching entities.
+		/// </summary>
+		/// <typeparam name="T">The type of entity to operate on.</typeparam>
+		/// <param name="entries">The List of <see cref="EntityEntry"/> records to operate on.</param>
+		/// <param name="actions">A mapping of actions to each state.</param>
+		/// <returns>The list of <see cref="EntityEntry"/> used as input, now modified as per <paramref name="actions"></paramref>.</returns>
+		/// <remarks>This is meant to be used on overloaded <see cref="DbContext.SaveChanges"/>.</remarks>
+#pragma warning restore CS0419 // Ambiguous reference in cref attribute
+		public static List<EntityEntry> ConfigureEntity<T>(
+			this List<EntityEntry> entries,
+			Dictionary<EntityState, Action<T>> actions)
+			where T : class
+		{
+			foreach (var entry in entries.Where(x => x.Entity is T).Where(x => actions.ContainsKey(x.State)))
+			{
+				var entity = entry.Entity as T ?? throw new InvalidCastException(nameof(T));
+				actions[entry.State](entity);
+			}
+
+			return entries;
+		}
+
+		/// <summary>
+		/// Timestamps entities that implement <see cref="ITimestamped"/>.
+		/// </summary>
+		/// <param name="entries">The List of <see cref="EntityEntry"/> records to operate on.</param>
+		/// <param name="now"><see cref="DateTimeOffset"/> that will be used for stamping.</param>
+		/// <returns>The list of <see cref="EntityEntry"/> used as input, now timestamped.</returns>
+		public static List<EntityEntry> TimeStampEntityEntries(this List<EntityEntry> entries, DateTimeOffset now)
+			=> entries.ConfigureEntity(new Dictionary<EntityState, Action<ITimestamped>>
+			{
+				{ EntityState.Modified, x => x.UpdatedAt = now },
+				{
+					EntityState.Added, x =>
+					{
+						x.UpdatedAt = now;
+						x.CreatedAt = now;
+					}
+				},
+			});
+
+		/// <summary>
+		/// Sets audit fields for entities that implement <see cref="IAuditable{T}"/>.
+		/// </summary>
+		/// <typeparam name="T">Type of auditor identifying field.</typeparam>
+		/// <param name="entries">The List of <see cref="EntityEntry"/> records to operate on.</param>
+		/// <param name="auditor">The auditor that will be set.</param>
+		/// <returns>The list of <see cref="EntityEntry"/> used as input, now audit-timestamped.</returns>
+		public static List<EntityEntry> AuditEntities<T>(this List<EntityEntry> entries, T auditor)
+			=> entries.ConfigureEntity(new Dictionary<EntityState, Action<IAuditable<T>>>
+			{
+				{ EntityState.Modified, x => x.UpdatedBy = auditor },
+				{
+					EntityState.Added, x =>
+					{
+						x.CreatedBy = auditor;
+						x.UpdatedBy = auditor;
+					}
+				},
+			});
+	}
+}

--- a/tests/Configuration.PersistenceTests/ChangeTrackerExtensionTests.cs
+++ b/tests/Configuration.PersistenceTests/ChangeTrackerExtensionTests.cs
@@ -1,0 +1,40 @@
+namespace Kritikos.Configuration.PersistenceTests
+{
+	using System;
+
+	using Xunit;
+
+	public class ChangeTrackerExtensionTests
+	{
+		[Fact]
+		public void EnsureAudited()
+		{
+			var ctx = new TestContext();
+
+			var person = new Person { Name = "Alex" };
+
+			ctx.Add(person);
+			ctx.SaveChanges();
+
+			Assert.True(person.CreatedBy == TestContext.DefaultUser, "IAuditable.CreatedBy was not set properly!");
+			Assert.True(person.UpdatedBy == TestContext.DefaultUser, "IAuditable.UpdatedBy was not set properly!");
+		}
+
+		[Fact]
+		public void EnsureTimestamped()
+		{
+			var ctx = new TestContext();
+
+			var person = new Person { Name = "Alex" };
+			var now = DateTimeOffset.Now;
+
+			ctx.Add(person);
+			var records = ctx.SaveChanges(now);
+
+
+			Assert.Equal(1,records);
+			Assert.True(person.CreatedAt == now, "ITimestamped.CreatedBy was not updated!");
+			Assert.True(person.UpdatedAt == now, "ITimestamped.UpdatedBy was not updated!");
+		}
+	}
+}

--- a/tests/Configuration.PersistenceTests/TestContext.cs
+++ b/tests/Configuration.PersistenceTests/TestContext.cs
@@ -1,7 +1,11 @@
 namespace Kritikos.Configuration.PersistenceTests
 {
+	using System;
 	using System.Diagnostics.CodeAnalysis;
+	using System.Linq;
 
+	using Kritikos.Configuration.Persistence;
+	using Kritikos.Configuration.Persistence.Abstractions;
 	using Kritikos.Configuration.Persistence.Base;
 
 	using Microsoft.EntityFrameworkCore;
@@ -10,6 +14,8 @@ namespace Kritikos.Configuration.PersistenceTests
 	[SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Local")]
 	public class TestContext : DbContext
 	{
+		public const string DefaultUser = "Test";
+
 #nullable disable
 		public DbSet<Person> People { get; private set; }
 #nullable enable
@@ -20,10 +26,59 @@ namespace Kritikos.Configuration.PersistenceTests
 				optionsBuilder.UseInMemoryDatabase("inMemory");
 			}
 		}
+
+
+		public int SaveChanges(DateTimeOffset? now)
+		{
+			now ??= DateTimeOffset.Now;
+			
+			ChangeTracker.Entries()
+				.ToList()
+				.TimeStampEntityEntries(now.Value)
+				.AuditEntities(DefaultUser);
+
+			return base.SaveChanges();
+		}
+
+		#region Overrides of DbContext
+
+		/// <inheritdoc />
+		public override int SaveChanges()
+		{
+			var now = DateTimeOffset.Now;
+			ChangeTracker.Entries()
+				.ToList()
+				.TimeStampEntityEntries(now)
+				.AuditEntities(DefaultUser);
+
+			return base.SaveChanges();
+		}
+
+		#endregion
 	}
 
-	public class Person : ConcurrentEntity<long>
+	public class Person : ConcurrentEntity<long>, IAuditable<string>, ITimestamped
 	{
 		public string Name { get; set; } = string.Empty;
+
+		#region Implementation of IAuditable<string>
+
+		/// <inheritdoc />
+		public string CreatedBy { get; set; } = string.Empty;
+
+		/// <inheritdoc />
+		public string UpdatedBy { get; set; } = string.Empty;
+
+		#endregion
+
+		#region Implementation of ITimestamped
+
+		/// <inheritdoc />
+		public DateTimeOffset CreatedAt { get; set; }
+
+		/// <inheritdoc />
+		public DateTimeOffset UpdatedAt { get; set; }
+
+		#endregion
 	}
 }


### PR DESCRIPTION
- Implements ChangeTracker extension methods that can be used to extend DbContext.SaveChanges with runtime behaviors