### PR TITLE
🔇 Removes description from succesful health checks

### DIFF
--- a/src/Configuration.Persistence.HealthCheck/DbContextHealthCheck.cs
+++ b/src/Configuration.Persistence.HealthCheck/DbContextHealthCheck.cs
@@ -66,7 +66,7 @@ namespace Kritikos.Configuration.Persistence.HealthCheck
 
         logger.LogInformation(DbContextHealthLogTemplates.DatabaseMigrated, DbName);
 
-        return HealthCheckResult.Healthy($"{DbName} is operating and healthy");
+        return HealthCheckResult.Healthy();
       }
       catch (Exception ex)
       {


### PR DESCRIPTION
Silences output on successful checks to reduce noise